### PR TITLE
fix issue with plone.supermodel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.0a3 (unreleased)
 ------------------
 
+- Support for use the widget with plone.supermodel
+  [jpgimenez]
+
 - Support for widget display settings as described in
   https://developers.google.com/recaptcha/docs/display
   [jensens]

--- a/src/plone/formwidget/recaptcha/widget.py
+++ b/src/plone/formwidget/recaptcha/widget.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 from Acquisition import aq_inner
 from plone.formwidget.recaptcha.interfaces import IReCaptchaWidget
+from z3c.form import interfaces
 from z3c.form import widget
 from z3c.form.browser import text
 from zope.component import getMultiAdapter
+import zope.component
 import zope.interface
 import zope.schema.interfaces
 
@@ -29,6 +31,8 @@ class ReCaptchaWidget(text.TextWidget):
         return self.captcha.audio_url()
 
 
+@zope.component.adapter(zope.schema.interfaces.IField, interfaces.IFormLayer)
+@zope.interface.implementer(interfaces.IFieldWidget)
 def ReCaptchaFieldWidget(field, request):
     """IFieldWidget factory for CaptchaWidget."""
     return widget.FieldWidget(field, ReCaptchaWidget(request))


### PR DESCRIPTION
with this change a recaptcha field could be defined in a supermodel XML:

```
    <field type="zope.schema.TextLine"
           name="captcha"
           form:omitted="z3c.form.interfaces.IDisplayForm:true"
           form:validator="plone.formwidget.recaptcha.validator.ReCaptchaValidator">
        <title>Captcha</title>
        <form:widget type="plone.formwidget.recaptcha.widget.ReCaptchaFieldWidget"/>
        <required>False</required>        
    </field>
```
