### PR TITLE
Add a dummy widget display view which renders empty.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+2.0 (2017-09-04)
+----------------
+
+- Add a dummy widget display view which renders empty.
+  A widget needs a display view, otherwise form result rendering may fail.
+  [thet]
+
+
 2.0a3 (2016-12-21)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '2.0a3'
+version = '2.0.dev0'
 
 description = open("README.rst").read() + "\n"
 description += open("CHANGES.rst").read()

--- a/src/plone/formwidget/recaptcha/configure.zcml
+++ b/src/plone/formwidget/recaptcha/configure.zcml
@@ -84,6 +84,13 @@
 
   <z3c:widgetTemplate
       layer="z3c.form.interfaces.IFormLayer"
+      mode="display"
+      template="widget_display.pt"
+      widget="plone.formwidget.recaptcha.interfaces.IReCaptchaWidget"
+  />
+
+  <z3c:widgetTemplate
+      layer="z3c.form.interfaces.IFormLayer"
       mode="input"
       template="widget.pt"
       widget="plone.formwidget.recaptcha.interfaces.IReCaptchaWidget"

--- a/src/plone/formwidget/recaptcha/widget_display.pt
+++ b/src/plone/formwidget/recaptcha/widget_display.pt
@@ -1,0 +1,1 @@
+<tal:comment condition="nothing">The widget isn't shown display mode</tal:comment>


### PR DESCRIPTION
A widget needs a display view, otherwise form result rendering may fail.