### PR TITLE
Do not validate captcha field upon z3c form inline validation.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,9 +20,9 @@ New features:
 
 Bug fixes:
 
-
 - Format code according to Plone standards: black, isort, zpretty. (#27)
 - Move CI from TravisCI to Github Actions [jensens] (#29)
+- Do not validate captcha field upon z3c form inline validation. [mathias.leimgruber]
 
 
 2.2.0 (2019-07-10)

--- a/src/plone/formwidget/recaptcha/view.py
+++ b/src/plone/formwidget/recaptcha/view.py
@@ -57,6 +57,14 @@ class RecaptchaView(BrowserView):
         return None
 
     def verify(self, input=None):
+
+        # Do not validate recaptcha on form inline validation.
+        # This automatically makes the next request (form submit) already
+        # invalid. This usually happens if the captcha is not the last field
+        # on a form.
+        if self.request.URL.endswith('z3cform_validate_field'):
+            return
+
         info = IRecaptchaInfo(self.request)
         if info.verified:
             return True


### PR DESCRIPTION
Do not validate recaptcha on form inline validation. This automatically makes the next request (form submit) already invalid. This usually happens if the captcha is not the last field

Example:
<img width="937" alt="Screenshot 2021-07-23 at 11 54 20" src="https://user-images.githubusercontent.com/437933/126810694-bf9bcb15-1320-4d4e-b5ab-e323344fd164.png">

It also happens if the captcha gets resolved first and `blur` gets triggered on any other field.