### PR TITLE
provide a default validator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,12 @@ To actually use the service, you must obtain a site key and secret key from
 
 Usage
 -----
+
+The ReCaptcha validator will be enabled by default in all of your forms that use the ReCaptcha Field and Widget.
+
 See the `demo <https://github.com/plone/plone.formwidget.recaptcha/tree/master/src/plone/formwidget/recaptcha/demo>`_ folder inside the distribution for an example usage.
+
+
 
 Supermodel
 ^^^^^^^^^^

--- a/news/+defaultvalidator.feature
+++ b/news/+defaultvalidator.feature
@@ -1,0 +1,1 @@
+Provide a default validator for the recaptcha field @erral

--- a/src/plone/formwidget/recaptcha/configure.zcml
+++ b/src/plone/formwidget/recaptcha/configure.zcml
@@ -142,4 +142,13 @@
       mode="input"
       />
 
+  <adapter
+      factory=".validator.ReCaptchaValidator"
+      for="*
+           .interfaces.IReCaptchaLayer
+           *
+           *
+           .interfaces.IReCaptchaWidget"
+      />
+
 </configure>

--- a/src/plone/formwidget/recaptcha/demo/form.py
+++ b/src/plone/formwidget/recaptcha/demo/form.py
@@ -1,4 +1,3 @@
-from Acquisition import aq_inner
 from plone.formwidget.recaptcha.widget import ReCaptchaFieldWidget
 from plone.z3cform.layout import wrap_form
 from z3c.form import button
@@ -6,7 +5,6 @@ from z3c.form import field
 from z3c.form import form
 from zope import interface
 from zope import schema
-from zope.component import getMultiAdapter
 
 import logging
 

--- a/src/plone/formwidget/recaptcha/demo/form.py
+++ b/src/plone/formwidget/recaptcha/demo/form.py
@@ -37,13 +37,9 @@ class BaseForm(form.Form):
     @button.buttonAndHandler("Save")
     def handleApply(self, action):
         data, errors = self.extractData()
-        captcha = getMultiAdapter(
-            (aq_inner(self.context), self.request), name="recaptcha"
-        )
-        if captcha.verify():
-            logger.info("ReCaptcha validation passed.")
-        else:
-            logger.info("The code you entered was wrong, please enter the new one.")
+
+        if errors:
+            self.status = "There was an error"
         return
 
 

--- a/src/plone/formwidget/recaptcha/validator.py
+++ b/src/plone/formwidget/recaptcha/validator.py
@@ -15,6 +15,7 @@ class ReCaptchaValidator(validator.SimpleFieldValidator):
         captcha = getMultiAdapter(
             (aq_inner(self.context), self.request), name="recaptcha"
         )
+
         if not captcha.verify():
             raise WrongCaptchaCode
         return True


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

Provide a default validator, this way z3c.form automatically calls the recaptcha validator upon form submission, without needing to manually do anything in our forms.